### PR TITLE
✨ feat: add automatic cleanup for GitHub deployments on delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This action deploys your static site to Cloudflare Pages or deletes an existing 
 - Delete existing Cloudflare Pages projects
 - Configure custom headers for deployed sites
 - Create GitHub deployments for PR previews with automatic cleanup
+- Automatically comment on PRs with deployment URLs
 - Works with Wrangler v4
 - Returns the deployment URL
 
@@ -54,6 +55,7 @@ Example:
 GitHub token for creating deployment statuses on the PR. This will add visible deployments to pull requests.
 If not provided, the action will not create a GitHub deployment (no error will be thrown).
 When used with `EVENT: "delete"`, this token will also deactivate any GitHub deployments for the PR.
+Additionally, when provided, the action will automatically post comments on the PR with deployment URLs.
 
 ### `ENVIRONMENT_NAME`
 
@@ -111,9 +113,6 @@ jobs:
           HEADERS: '{"version.json":{"cacheControl":"max-age=0,no-cache,no-store,must-revalidate"}}'
           GITHUB_TOKEN: ${{ github.token }}
           ENVIRONMENT_NAME: 'preview'
-      
-      - name: Output deployment URL
-        run: echo "Deployed to ${{ steps.deployment.outputs.url }}"
 ```
 
 ### Standard Deployment Without GitHub Deployments
@@ -174,6 +173,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       deployments: write
+      pull-requests: write
     steps:
       - name: Delete Cloudflare Pages deployment
         uses: zero-copy-labs/deploy-ui-to-cloudflare@v1
@@ -183,7 +183,7 @@ jobs:
           PROJECT_NAME: 'my-project'
           DIST_FOLDER: '.'  # Not used for delete but required
           EVENT: 'delete'
-          GITHUB_TOKEN: ${{ github.token }}  # For deactivating GitHub deployments
+          GITHUB_TOKEN: ${{ github.token }}  # For deactivating GitHub deployments and posting comments
           ENVIRONMENT_NAME: 'preview'
 ```
 
@@ -200,6 +200,8 @@ jobs:
 4. **Headers not applied**: Verify that your `HEADERS` JSON is valid and properly formatted.
 
 5. **GitHub deployments not showing**: Ensure your workflow has the `deployments: write` permission.
+
+6. **PR comments not showing**: Ensure your workflow has the `pull-requests: write` permission.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This action deploys your static site to Cloudflare Pages or deletes an existing 
 - Deploy static sites to Cloudflare Pages
 - Delete existing Cloudflare Pages projects
 - Configure custom headers for deployed sites
-- Create GitHub deployments for PR previews
+- Create GitHub deployments for PR previews with automatic cleanup
 - Works with Wrangler v4
 - Returns the deployment URL
 
@@ -53,6 +53,7 @@ Example:
 
 GitHub token for creating deployment statuses on the PR. This will add visible deployments to pull requests.
 If not provided, the action will not create a GitHub deployment (no error will be thrown).
+When used with `EVENT: "delete"`, this token will also deactivate any GitHub deployments for the PR.
 
 ### `ENVIRONMENT_NAME`
 
@@ -159,7 +160,7 @@ jobs:
         run: echo "Deployed to ${{ steps.deployment.outputs.url }}"
 ```
 
-### Delete a deployment
+### Delete a deployment and clean up GitHub deployments
 
 ```yaml
 name: Cleanup Cloudflare Pages Project
@@ -171,6 +172,8 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      deployments: write
     steps:
       - name: Delete Cloudflare Pages deployment
         uses: zero-copy-labs/deploy-ui-to-cloudflare@v1
@@ -180,6 +183,8 @@ jobs:
           PROJECT_NAME: 'my-project'
           DIST_FOLDER: '.'  # Not used for delete but required
           EVENT: 'delete'
+          GITHUB_TOKEN: ${{ github.token }}  # For deactivating GitHub deployments
+          ENVIRONMENT_NAME: 'preview'
 ```
 
 ## Troubleshooting

--- a/index.mjs
+++ b/index.mjs
@@ -40,25 +40,104 @@ async function run() {
     if (event === 'deploy') {
       const deployUrl = await deployToCloudflare(distFolder, projectName, branch, headers);
       
-      // Create GitHub deployment if token is provided
+      // If we have a GitHub token, create a deployment and post a comment
       if (githubToken) {
         await createGitHubDeployment(githubToken, deployUrl, environmentName);
+        await commentOnPR(githubToken, deployUrl);
       } else {
-        core.info('No GitHub token provided, skipping deployment status creation');
+        core.info('No GitHub token provided, skipping deployment status creation and PR comment');
       }
     } else {
       await deleteFromCloudflare(projectName);
       
-      // Deactivate GitHub deployments if token is provided
+      // If we have a GitHub token, deactivate deployments and post a cleanup comment
       if (githubToken) {
         await deactivateGitHubDeployments(githubToken, environmentName);
+        await commentOnPRCleanup(githubToken);
       } else {
-        core.info('No GitHub token provided, skipping deployment deactivation');
+        core.info('No GitHub token provided, skipping deployment deactivation and PR comment');
       }
     }
 
   } catch (error) {
     core.setFailed(`Action failed: ${error.message}`);
+  }
+}
+
+/**
+ * Post a comment on the PR with the deployment URL
+ * @param {string} token - GitHub token
+ * @param {string} deployUrl - URL of the deployment
+ * @returns {Promise<void>}
+ */
+async function commentOnPR(token, deployUrl) {
+  try {
+    const octokit = github.getOctokit(token);
+    const context = github.context;
+    
+    // Only comment on pull requests
+    if (!context.payload.pull_request) {
+      core.info('Not a pull request, skipping comment creation');
+      return;
+    }
+    
+    const prNumber = context.payload.pull_request.number;
+    
+    core.info(`Posting deployment comment on PR #${prNumber}`);
+    
+    try {
+      await octokit.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+        body: `🚀 PR Preview deployed to: ${deployUrl}`
+      });
+      
+      core.info(`Successfully posted comment on PR #${prNumber}`);
+    } catch (error) {
+      // Don't fail the action if comment creation fails
+      core.warning(`Failed to post comment on PR: ${error.message}`);
+    }
+  } catch (error) {
+    core.warning(`Error posting comment on PR: ${error.message}`);
+  }
+}
+
+/**
+ * Post a comment on the PR about cleanup
+ * @param {string} token - GitHub token
+ * @returns {Promise<void>}
+ */
+async function commentOnPRCleanup(token) {
+  try {
+    const octokit = github.getOctokit(token);
+    const context = github.context;
+    
+    // Only comment on pull requests
+    if (!context.payload.pull_request) {
+      core.info('Not a pull request, skipping cleanup comment');
+      return;
+    }
+    
+    const prNumber = context.payload.pull_request.number;
+    
+    core.info(`Posting cleanup comment on PR #${prNumber}`);
+    
+    try {
+      await octokit.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+        body: `🧹 PR Preview environment has been cleaned up.`
+      });
+      
+      core.info(`Successfully posted cleanup comment on PR #${prNumber}`);
+    } catch (error) {
+      // Don't fail the action if comment creation fails
+      core.warning(`Failed to post cleanup comment on PR: ${error.message}`);
+    }
+  } catch (error) {
+    core.warning(`Error posting cleanup comment on PR: ${error.message}`);
   }
 }
 


### PR DESCRIPTION
This update enhances the action by introducing a new function to deactivate GitHub deployments when a project is deleted. Key changes include:
- Implementation of `deactivateGitHubDeployments` function to handle the cleanup of active deployments for pull requests.
- Updated README to reflect the new functionality and usage instructions for the GitHub token.
- Improved messaging for deployment deactivation status.

This enhancement ensures that GitHub deployments are properly cleaned up, improving resource management and integration with GitHub workflows.