### PR TITLE
✨ feat: enhance deployment management with cleanup options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,18 @@ inputs:
     description: 'Automatically create the Cloudflare Pages project if it does not exist'
     required: false
     default: 'true'
+  CLEANUP_OLD_DEPLOYMENTS:
+    description: 'Clean up old deployments to avoid hitting the deployment limit'
+    required: false
+    default: 'false'
+  DEPLOYMENT_PREFIX:
+    description: 'Prefix to match when cleaning up or deleting deployments (e.g. the branch name)'
+    required: false
+    default: ''
+  KEEP_DEPLOYMENTS:
+    description: 'Number of deployments to keep when cleaning up (oldest will be deleted)'
+    required: false
+    default: '5'
 outputs:
   url:
     description: 'URL of the deployed site (only available when EVENT is "deploy")'


### PR DESCRIPTION
This update introduces new inputs for managing deployments in Cloudflare Pages. Key changes include:
- Added `CLEANUP_OLD_DEPLOYMENTS` to enable automatic cleanup of old deployments.
- Introduced `DEPLOYMENT_PREFIX` for targeted deletion of deployments based on a specified prefix.
- New input `KEEP_DEPLOYMENTS` to define the number of recent deployments to retain during cleanup.
- Updated README to reflect these new features and provide usage examples.

These enhancements improve the action's ability to manage deployments effectively, preventing users from hitting deployment limits and streamlining the deployment process.